### PR TITLE
✨ feat: implement `isEquivalentTo` method

### DIFF
--- a/.squad/agents/morpheus/history.md
+++ b/.squad/agents/morpheus/history.md
@@ -21,3 +21,5 @@ Morpheus initialized to evolve the library and its integration.
 - Invalid forms like `[* TO x]` and `[x TO *]` should fail fast with a parse error to avoid ambiguous API behavior.
 - Bracket value expressions like `[abc]` and `[a-z]` can coexist with range syntax when range detection is "range-like" rather than "starts with [".
 - Preserving historical parse failures requires explicit handling of malformed range-shaped literals (e.g. `18 TO 65]`) so they are not silently parsed as equals.
+- Equivalence semantics are safest when centralized in a shared utility and exposed through `IFilter.isEquivalentTo`, keeping reflexive/symmetric behavior consistent across all filter classes.
+- Delivery note (2026-04-19): implementation completed and validated with focused suites on `equals` and `and` filters.

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -14,5 +14,6 @@ Agent Scribe initialized and ready for work.
 ## Learnings
 
 Initial setup complete.
+
 - Decision inbox handling should merge proposals into `decisions.md`, deduplicate, then clear inbox artifacts in the same documentation session.
 - For multi-agent deliveries, keep orchestration logs and cross-agent history updates synchronized with the same timestamped session note.

--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -14,3 +14,5 @@ Agent Scribe initialized and ready for work.
 ## Learnings
 
 Initial setup complete.
+- Decision inbox handling should merge proposals into `decisions.md`, deduplicate, then clear inbox artifacts in the same documentation session.
+- For multi-agent deliveries, keep orchestration logs and cross-agent history updates synchronized with the same timestamped session note.

--- a/.squad/agents/switch/history.md
+++ b/.squad/agents/switch/history.md
@@ -17,3 +17,4 @@ Switch initialized to secure evolution through tests.
 - Parser error scenarios are critical to validate.
 - Equivalence coverage should assert reflexivity and symmetry explicitly, including cross-shape equivalence like `EqualsFilter` vs `AndFilter([equalFilter, equalFilter])` in both directions.
 - Delivery note (2026-04-19): focused verification completed with `npm test -- test/equalsFilter.test.ts test/andFilter.test.ts --runInBand` passing.
+- Delivery note (2026-04-19): extended equivalence coverage pattern (self, same-shape equivalent, different-shape non-equivalent) across all concrete filter tests and added dedicated `OneOfFilter` test suite.

--- a/.squad/agents/switch/history.md
+++ b/.squad/agents/switch/history.md
@@ -15,3 +15,5 @@ Switch initialized to secure evolution through tests.
 - The repository already has a foundation of unit tests for filters.
 - Test coverage should focus on edge cases and error handling.
 - Parser error scenarios are critical to validate.
+- Equivalence coverage should assert reflexivity and symmetry explicitly, including cross-shape equivalence like `EqualsFilter` vs `AndFilter([equalFilter, equalFilter])` in both directions.
+- Delivery note (2026-04-19): focused verification completed with `npm test -- test/equalsFilter.test.ts test/andFilter.test.ts --runInBand` passing.

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -48,6 +48,15 @@
     - Preserves backward compatibility for existing parser/serialization APIs.
     - Satisfies required `EqualsFilter` <-> `AndFilter([same, same])` behavior.
 
+- 2026-04-19T00:00:00Z | Branching policy for all squad work
+  - By: Cyrille NDOUMBE (via Copilot)
+  - Decision: Never commit directly to `develop`.
+  - Workflow:
+    - Follow gitflow for all team work.
+    - Create an appropriate branch before starting any implementation, test, documentation, or review-related change.
+    - Treat `develop` as an integration branch only.
+  - Rationale: User directive captured for team continuity and branch safety.
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -36,6 +36,18 @@
   - Decision: Use small iterative conventional commits while working on this feature.
   - Rationale: User directive captured for team continuity.
 
+- 2026-04-19T00:00:00Z | Filter equivalence contract and shared semantics
+  - By: Morpheus
+  - Decision: Add `isEquivalentTo(other: IFilter): boolean` to the `IFilter` contract and implement it for all concrete filters via a shared equivalence utility.
+  - Semantics:
+    - Reflexive and symmetric equivalence.
+    - Structural baseline uses deep equality on `toDict()` payloads.
+    - Bridge behavior: a filter is equivalent to an `AndFilter` when each `AndFilter` child is equivalent to that filter (and vice versa).
+  - Rationale:
+    - Enforces one equivalence path for all filter types.
+    - Preserves backward compatibility for existing parser/serialization APIs.
+    - Satisfies required `EqualsFilter` <-> `AndFilter([same, same])` behavior.
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/src/andFilter.ts
+++ b/src/andFilter.ts
@@ -1,10 +1,15 @@
-import { IFilter } from './iFilter';
+import { IFilter } from "./iFilter";
+import { areFiltersEquivalent } from "./equivalence";
 
 /** Combines multiple filters with a logical AND. */
 export class AndFilter implements IFilter {
   public constructor(public readonly filters: IFilter[]) {}
 
   public toDict(): Record<string, unknown> {
-    return { logic: 'and', filters: this.filters.map((f) => f.toDict()) };
+    return { logic: "and", filters: this.filters.map((f) => f.toDict()) };
+  }
+
+  public isEquivalentTo(other: IFilter): boolean {
+    return areFiltersEquivalent(this, other);
   }
 }

--- a/src/containsFilter.ts
+++ b/src/containsFilter.ts
@@ -1,4 +1,5 @@
 import { IFilter } from "./iFilter";
+import { areFiltersEquivalent } from "./equivalence";
 
 /** Matches records where a property contains a substring. */
 export class ContainsFilter implements IFilter {
@@ -9,6 +10,10 @@ export class ContainsFilter implements IFilter {
 
   public toDict(): Record<string, unknown> {
     return { field: this.field, op: "contains", value: this.value };
+  }
+
+  public isEquivalentTo(other: IFilter): boolean {
+    return areFiltersEquivalent(this, other);
   }
 
   /**

--- a/src/endsWithFilter.ts
+++ b/src/endsWithFilter.ts
@@ -1,10 +1,18 @@
-import { IFilter } from './iFilter';
+import { IFilter } from "./iFilter";
+import { areFiltersEquivalent } from "./equivalence";
 
 /** Matches records where a property ends with a specific string. */
 export class EndsWithFilter implements IFilter {
-  public constructor(public readonly field: string, public readonly value: string) {}
+  public constructor(
+    public readonly field: string,
+    public readonly value: string,
+  ) {}
 
   public toDict(): Record<string, unknown> {
-    return { field: this.field, op: 'endswith', value: this.value };
+    return { field: this.field, op: "endswith", value: this.value };
+  }
+
+  public isEquivalentTo(other: IFilter): boolean {
+    return areFiltersEquivalent(this, other);
   }
 }

--- a/src/equalsFilter.ts
+++ b/src/equalsFilter.ts
@@ -1,10 +1,18 @@
-import { IFilter } from './iFilter';
+import { IFilter } from "./iFilter";
+import { areFiltersEquivalent } from "./equivalence";
 
 /** Matches records where a property equals a specific value. */
 export class EqualsFilter implements IFilter {
-  public constructor(public readonly field: string, public readonly value: unknown) {}
+  public constructor(
+    public readonly field: string,
+    public readonly value: unknown,
+  ) {}
 
   public toDict(): Record<string, unknown> {
-    return { field: this.field, op: 'eq', value: this.value };
+    return { field: this.field, op: "eq", value: this.value };
+  }
+
+  public isEquivalentTo(other: IFilter): boolean {
+    return areFiltersEquivalent(this, other);
   }
 }

--- a/src/equivalence.ts
+++ b/src/equivalence.ts
@@ -1,0 +1,82 @@
+import { IFilter } from "./iFilter";
+
+type AndLikeFilter = IFilter & { filters: IFilter[] };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isFilter = (value: unknown): value is IFilter =>
+  isRecord(value) &&
+  typeof value["toDict"] === "function" &&
+  typeof value["isEquivalentTo"] === "function";
+
+const deepEqual = (left: unknown, right: unknown): boolean => {
+  if (Object.is(left, right)) {
+    return true;
+  }
+
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length &&
+      left.every((value, index) => deepEqual(value, right[index]))
+    );
+  }
+
+  if (isRecord(left) && isRecord(right)) {
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+
+    if (leftKeys.length !== rightKeys.length) {
+      return false;
+    }
+
+    return leftKeys.every(
+      (key) => key in right && deepEqual(left[key], right[key]),
+    );
+  }
+
+  return false;
+};
+
+const getAndFilters = (filter: IFilter): IFilter[] | undefined => {
+  const dict = filter.toDict();
+  if (dict["logic"] !== "and") {
+    return undefined;
+  }
+
+  const andFilter = filter as Partial<AndLikeFilter>;
+  if (!Array.isArray(andFilter.filters) || andFilter.filters.length === 0) {
+    return undefined;
+  }
+
+  if (!andFilter.filters.every((child) => isFilter(child))) {
+    return undefined;
+  }
+
+  return andFilter.filters;
+};
+
+export const areFiltersEquivalent = (
+  left: IFilter,
+  right: IFilter,
+): boolean => {
+  if (left === right) {
+    return true;
+  }
+
+  if (deepEqual(left.toDict(), right.toDict())) {
+    return true;
+  }
+
+  const leftAndFilters = getAndFilters(left);
+  if (leftAndFilters?.every((child) => child.isEquivalentTo(right))) {
+    return true;
+  }
+
+  const rightAndFilters = getAndFilters(right);
+  if (rightAndFilters?.every((child) => child.isEquivalentTo(left))) {
+    return true;
+  }
+
+  return false;
+};

--- a/src/greaterThanFilter.ts
+++ b/src/greaterThanFilter.ts
@@ -1,10 +1,18 @@
-import { IFilter } from './iFilter';
+import { IFilter } from "./iFilter";
+import { areFiltersEquivalent } from "./equivalence";
 
 /** Matches records where a property is greater than a value. */
 export class GreaterThanFilter implements IFilter {
-  public constructor(public readonly field: string, public readonly value: unknown) {}
+  public constructor(
+    public readonly field: string,
+    public readonly value: unknown,
+  ) {}
 
   public toDict(): Record<string, unknown> {
-    return { field: this.field, op: 'gt', value: this.value };
+    return { field: this.field, op: "gt", value: this.value };
+  }
+
+  public isEquivalentTo(other: IFilter): boolean {
+    return areFiltersEquivalent(this, other);
   }
 }

--- a/src/greaterThanOrEqualFilter.ts
+++ b/src/greaterThanOrEqualFilter.ts
@@ -1,10 +1,18 @@
-import { IFilter } from './iFilter';
+import { IFilter } from "./iFilter";
+import { areFiltersEquivalent } from "./equivalence";
 
 /** Matches records where a property is greater than or equal to a value. */
 export class GreaterThanOrEqualFilter implements IFilter {
-  public constructor(public readonly field: string, public readonly value: unknown) {}
+  public constructor(
+    public readonly field: string,
+    public readonly value: unknown,
+  ) {}
 
   public toDict(): Record<string, unknown> {
-    return { field: this.field, op: 'gte', value: this.value };
+    return { field: this.field, op: "gte", value: this.value };
+  }
+
+  public isEquivalentTo(other: IFilter): boolean {
+    return areFiltersEquivalent(this, other);
   }
 }

--- a/src/iFilter.ts
+++ b/src/iFilter.ts
@@ -2,4 +2,7 @@
 export interface IFilter {
   /** Converts the filter to a dictionary representation. */
   toDict(): Record<string, unknown>;
+
+  /** Tests whether this filter is equivalent to another filter. */
+  isEquivalentTo(other: IFilter): boolean;
 }

--- a/src/lessThanFilter.ts
+++ b/src/lessThanFilter.ts
@@ -1,10 +1,18 @@
-import { IFilter } from './iFilter';
+import { IFilter } from "./iFilter";
+import { areFiltersEquivalent } from "./equivalence";
 
 /** Matches records where a property is less than a value. */
 export class LessThanFilter implements IFilter {
-  public constructor(public readonly field: string, public readonly value: unknown) {}
+  public constructor(
+    public readonly field: string,
+    public readonly value: unknown,
+  ) {}
 
   public toDict(): Record<string, unknown> {
-    return { field: this.field, op: 'lt', value: this.value };
+    return { field: this.field, op: "lt", value: this.value };
+  }
+
+  public isEquivalentTo(other: IFilter): boolean {
+    return areFiltersEquivalent(this, other);
   }
 }

--- a/src/lessThanOrEqualFilter.ts
+++ b/src/lessThanOrEqualFilter.ts
@@ -1,10 +1,18 @@
-import { IFilter } from './iFilter';
+import { IFilter } from "./iFilter";
+import { areFiltersEquivalent } from "./equivalence";
 
 /** Matches records where a property is less than or equal to a value. */
 export class LessThanOrEqualFilter implements IFilter {
-  public constructor(public readonly field: string, public readonly value: unknown) {}
+  public constructor(
+    public readonly field: string,
+    public readonly value: unknown,
+  ) {}
 
   public toDict(): Record<string, unknown> {
-    return { field: this.field, op: 'lte', value: this.value };
+    return { field: this.field, op: "lte", value: this.value };
+  }
+
+  public isEquivalentTo(other: IFilter): boolean {
+    return areFiltersEquivalent(this, other);
   }
 }

--- a/src/notFilter.ts
+++ b/src/notFilter.ts
@@ -1,4 +1,5 @@
 import { IFilter } from "./iFilter";
+import { areFiltersEquivalent } from "./equivalence";
 
 /** Negates a filter expression. */
 export class NotFilter implements IFilter {
@@ -6,5 +7,9 @@ export class NotFilter implements IFilter {
 
   public toDict(): Record<string, unknown> {
     return { logic: "not", filters: [this.filter.toDict()] };
+  }
+
+  public isEquivalentTo(other: IFilter): boolean {
+    return areFiltersEquivalent(this, other);
   }
 }

--- a/src/oneOfFilter.ts
+++ b/src/oneOfFilter.ts
@@ -1,4 +1,5 @@
 import { IFilter } from "./iFilter";
+import { areFiltersEquivalent } from "./equivalence";
 
 /** Combines multiple filters with a logical OR. */
 
@@ -7,5 +8,9 @@ export class OneOfFilter implements IFilter {
 
   public toDict(): Record<string, unknown> {
     return { logic: "or", filters: this.filters.map((f) => f.toDict()) };
+  }
+
+  public isEquivalentTo(other: IFilter): boolean {
+    return areFiltersEquivalent(this, other);
   }
 }

--- a/src/orFilter.ts
+++ b/src/orFilter.ts
@@ -1,4 +1,5 @@
 import { IFilter } from "./iFilter";
+import { areFiltersEquivalent } from "./equivalence";
 
 export class OrFilter implements IFilter {
   public constructor(
@@ -8,5 +9,9 @@ export class OrFilter implements IFilter {
 
   public toDict(): Record<string, unknown> {
     return { logic: "or", filters: [this.left.toDict(), this.right.toDict()] };
+  }
+
+  public isEquivalentTo(other: IFilter): boolean {
+    return areFiltersEquivalent(this, other);
   }
 }

--- a/src/startsWithFilter.ts
+++ b/src/startsWithFilter.ts
@@ -1,10 +1,18 @@
-import { IFilter } from './iFilter';
+import { IFilter } from "./iFilter";
+import { areFiltersEquivalent } from "./equivalence";
 
 /** Matches records where a property starts with a specific string. */
 export class StartsWithFilter implements IFilter {
-  public constructor(public readonly field: string, public readonly value: string) {}
+  public constructor(
+    public readonly field: string,
+    public readonly value: string,
+  ) {}
 
   public toDict(): Record<string, unknown> {
-    return { field: this.field, op: 'startswith', value: this.value };
+    return { field: this.field, op: "startswith", value: this.value };
+  }
+
+  public isEquivalentTo(other: IFilter): boolean {
+    return areFiltersEquivalent(this, other);
   }
 }

--- a/test/andFilter.test.ts
+++ b/test/andFilter.test.ts
@@ -1,18 +1,68 @@
-import { AndFilter, EqualsFilter } from '../src/expressions';
+import { AndFilter, EqualsFilter } from "../src/expressions";
 
-describe('AndFilter', () => {
-  it('should serialize with logic and nested filters', () => {
+describe("AndFilter", () => {
+  it("should serialize with logic and nested filters", () => {
     // Arrange
     const f = new AndFilter([
-      new EqualsFilter('a', 1),
-      new EqualsFilter('b', 2),
+      new EqualsFilter("a", 1),
+      new EqualsFilter("b", 2),
     ]);
 
     // Act
     const result = f.toDict();
 
     // Assert
-    expect(result['logic']).toBe('and');
-    expect((result['filters'] as unknown[]).length).toBe(2);
+    expect(result["logic"]).toBe("and");
+    expect((result["filters"] as unknown[]).length).toBe(2);
+  });
+
+  it("should be equivalent to itself", () => {
+    // Arrange
+    const f = new AndFilter([
+      new EqualsFilter("a", 1),
+      new EqualsFilter("b", 2),
+    ]);
+
+    // Act
+    const result = f.isEquivalentTo(f);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it("should be equivalent to another AndFilter with same filters", () => {
+    // Arrange
+    const f1 = new AndFilter([
+      new EqualsFilter("a", 1),
+      new EqualsFilter("b", 2),
+    ]);
+    const f2 = new AndFilter([
+      new EqualsFilter("a", 1),
+      new EqualsFilter("b", 2),
+    ]);
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it("should not be equivalent to a different AndFilter", () => {
+    // Arrange
+    const f1 = new AndFilter([
+      new EqualsFilter("a", 1),
+      new EqualsFilter("b", 2),
+    ]);
+    const f2 = new AndFilter([
+      new EqualsFilter("a", 1),
+      new EqualsFilter("b", 3), // different value
+    ]);
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeFalsy();
   });
 });

--- a/test/containsFilter.test.ts
+++ b/test/containsFilter.test.ts
@@ -63,4 +63,39 @@ describe("ContainsFilter", () => {
       },
     );
   });
+
+  it("should be equivalent to itself", () => {
+    // Arrange
+    const f = new ContainsFilter("name", "bat");
+
+    // Act
+    const result = f.isEquivalentTo(f);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it("should be equivalent to another ContainsFilter with same values", () => {
+    // Arrange
+    const f1 = new ContainsFilter("name", "bat");
+    const f2 = new ContainsFilter("name", "bat");
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it("should not be equivalent to a different ContainsFilter", () => {
+    // Arrange
+    const f1 = new ContainsFilter("name", "bat");
+    const f2 = new ContainsFilter("name", "man");
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeFalsy();
+  });
 });

--- a/test/endsWithFilter.test.ts
+++ b/test/endsWithFilter.test.ts
@@ -19,4 +19,39 @@ describe('EndsWithFilter', () => {
     // Assert
     expect(dict['op']).toBe('endswith');
   });
+
+  it('should be equivalent to itself', () => {
+    // Arrange
+    const f = new EndsWithFilter('name', 'man');
+
+    // Act
+    const result = f.isEquivalentTo(f);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it('should be equivalent to another EndsWithFilter with same values', () => {
+    // Arrange
+    const f1 = new EndsWithFilter('name', 'man');
+    const f2 = new EndsWithFilter('name', 'man');
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it('should not be equivalent to a different EndsWithFilter', () => {
+    // Arrange
+    const f1 = new EndsWithFilter('name', 'man');
+    const f2 = new EndsWithFilter('name', 'bat');
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeFalsy();
+  });
 });

--- a/test/endsWithFilter.test.ts
+++ b/test/endsWithFilter.test.ts
@@ -1,28 +1,28 @@
-import { EndsWithFilter } from '../src/expressions';
+import { EndsWithFilter } from "../src/expressions";
 
-describe('EndsWithFilter', () => {
-  it('should serialize to correct dict', () => {
+describe("EndsWithFilter", () => {
+  it("should serialize to correct dict", () => {
     // Arrange
-    const f = new EndsWithFilter('name', 'man');
+    const f = new EndsWithFilter("name", "man");
 
     // Act
     const result = f.toDict();
 
     // Assert
-    expect(result).toEqual({ field: 'name', op: 'endswith', value: 'man' });
+    expect(result).toEqual({ field: "name", op: "endswith", value: "man" });
   });
 
-  it('op field should be endswith', () => {
+  it("op field should be endswith", () => {
     // Arrange / Act
-    const dict = new EndsWithFilter('f', 'v').toDict();
+    const dict = new EndsWithFilter("f", "v").toDict();
 
     // Assert
-    expect(dict['op']).toBe('endswith');
+    expect(dict["op"]).toBe("endswith");
   });
 
-  it('should be equivalent to itself', () => {
+  it("should be equivalent to itself", () => {
     // Arrange
-    const f = new EndsWithFilter('name', 'man');
+    const f = new EndsWithFilter("name", "man");
 
     // Act
     const result = f.isEquivalentTo(f);
@@ -31,10 +31,10 @@ describe('EndsWithFilter', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should be equivalent to another EndsWithFilter with same values', () => {
+  it("should be equivalent to another EndsWithFilter with same values", () => {
     // Arrange
-    const f1 = new EndsWithFilter('name', 'man');
-    const f2 = new EndsWithFilter('name', 'man');
+    const f1 = new EndsWithFilter("name", "man");
+    const f2 = new EndsWithFilter("name", "man");
 
     // Act
     const result = f1.isEquivalentTo(f2);
@@ -43,10 +43,10 @@ describe('EndsWithFilter', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should not be equivalent to a different EndsWithFilter', () => {
+  it("should not be equivalent to a different EndsWithFilter", () => {
     // Arrange
-    const f1 = new EndsWithFilter('name', 'man');
-    const f2 = new EndsWithFilter('name', 'bat');
+    const f1 = new EndsWithFilter("name", "man");
+    const f2 = new EndsWithFilter("name", "bat");
 
     // Act
     const result = f1.isEquivalentTo(f2);

--- a/test/equalsFilter.test.ts
+++ b/test/equalsFilter.test.ts
@@ -85,8 +85,20 @@ describe("EqualsFilter", () => {
       const andToEquals = isEquivalentTo(andFilter, equalFilter);
 
       // Assert
-      expect(equalsToAnd).toBe(true);
-      expect(andToEquals).toBe(true);
+      expect(equalsToAnd).toBeTruthy();
+      expect(andToEquals).toBeTruthy();
+    });
+
+    it("should not be equivalent to a different EqualsFilter", () => {
+      // Arrange
+      const left = new EqualsFilter("name", "Batman");
+      const right = new EqualsFilter("name", "Superman");
+
+      // Act
+      const result = left.isEquivalentTo(right);
+
+      // Assert
+      expect(result).toBeFalsy();
     });
   });
 });

--- a/test/equalsFilter.test.ts
+++ b/test/equalsFilter.test.ts
@@ -1,31 +1,92 @@
-import { EqualsFilter } from '../src/expressions';
+import { AndFilter, EqualsFilter } from "../src/expressions";
 
-describe('EqualsFilter', () => {
-  it('should serialize to correct dict', () => {
+const isEquivalentTo = (left: unknown, right: unknown): boolean => {
+  return (
+    left as { isEquivalentTo: (other: unknown) => boolean }
+  ).isEquivalentTo(right);
+};
+
+describe("EqualsFilter", () => {
+  it("should serialize to correct dict", () => {
     // Arrange
-    const f = new EqualsFilter('name', 'Batman');
+    const f = new EqualsFilter("name", "Batman");
 
     // Act
     const result = f.toDict();
 
     // Assert
-    expect(result).toEqual({ field: 'name', op: 'eq', value: 'Batman' });
+    expect(result).toEqual({ field: "name", op: "eq", value: "Batman" });
   });
 
-  it('should store field and value', () => {
+  it("should store field and value", () => {
     // Arrange / Act
-    const f = new EqualsFilter('age', 30);
+    const f = new EqualsFilter("age", 30);
 
     // Assert
-    expect(f.field).toBe('age');
+    expect(f.field).toBe("age");
     expect(f.value).toBe(30);
   });
 
-  it('op field should be eq', () => {
+  it("op field should be eq", () => {
     // Arrange / Act
-    const dict = new EqualsFilter('f', 'v').toDict();
+    const dict = new EqualsFilter("f", "v").toDict();
 
     // Assert
-    expect(dict['op']).toBe('eq');
+    expect(dict["op"]).toBe("eq");
+  });
+
+  describe("isEquivalentTo", () => {
+    it("should be reflexive for EqualsFilter", () => {
+      // Arrange
+      const filter = new EqualsFilter("name", "Batman");
+
+      // Act
+      const result = isEquivalentTo(filter, filter);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it("should be reflexive for AndFilter", () => {
+      // Arrange
+      const filter = new AndFilter([
+        new EqualsFilter("name", "Batman"),
+        new EqualsFilter("city", "Gotham"),
+      ]);
+
+      // Act
+      const result = isEquivalentTo(filter, filter);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it("should be symmetric for equivalent EqualsFilter instances", () => {
+      // Arrange
+      const left = new EqualsFilter("name", "Batman");
+      const right = new EqualsFilter("name", "Batman");
+
+      // Act
+      const leftToRight = isEquivalentTo(left, right);
+      const rightToLeft = isEquivalentTo(right, left);
+
+      // Assert
+      expect(leftToRight).toBe(true);
+      expect(rightToLeft).toBe(true);
+    });
+
+    it("should treat EqualsFilter and AndFilter([equalFilter, equalFilter]) as equivalent in both directions", () => {
+      // Arrange
+      const equalFilter = new EqualsFilter("name", "Batman");
+      const andFilter = new AndFilter([equalFilter, equalFilter]);
+
+      // Act
+      const equalsToAnd = isEquivalentTo(equalFilter, andFilter);
+      const andToEquals = isEquivalentTo(andFilter, equalFilter);
+
+      // Assert
+      expect(equalsToAnd).toBe(true);
+      expect(andToEquals).toBe(true);
+    });
   });
 });

--- a/test/greaterThanFilter.test.ts
+++ b/test/greaterThanFilter.test.ts
@@ -19,4 +19,39 @@ describe('GreaterThanFilter', () => {
     // Assert
     expect(dict['op']).toBe('gt');
   });
+
+  it('should be equivalent to itself', () => {
+    // Arrange
+    const f = new GreaterThanFilter('age', 18);
+
+    // Act
+    const result = f.isEquivalentTo(f);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it('should be equivalent to another GreaterThanFilter with same values', () => {
+    // Arrange
+    const f1 = new GreaterThanFilter('age', 18);
+    const f2 = new GreaterThanFilter('age', 18);
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it('should not be equivalent to a different GreaterThanFilter', () => {
+    // Arrange
+    const f1 = new GreaterThanFilter('age', 18);
+    const f2 = new GreaterThanFilter('age', 21);
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeFalsy();
+  });
 });

--- a/test/greaterThanFilter.test.ts
+++ b/test/greaterThanFilter.test.ts
@@ -1,28 +1,28 @@
-import { GreaterThanFilter } from '../src/expressions';
+import { GreaterThanFilter } from "../src/expressions";
 
-describe('GreaterThanFilter', () => {
-  it('should serialize to correct dict', () => {
+describe("GreaterThanFilter", () => {
+  it("should serialize to correct dict", () => {
     // Arrange
-    const f = new GreaterThanFilter('age', 18);
+    const f = new GreaterThanFilter("age", 18);
 
     // Act
     const result = f.toDict();
 
     // Assert
-    expect(result).toEqual({ field: 'age', op: 'gt', value: 18 });
+    expect(result).toEqual({ field: "age", op: "gt", value: 18 });
   });
 
-  it('op field should be gt', () => {
+  it("op field should be gt", () => {
     // Arrange / Act
-    const dict = new GreaterThanFilter('f', 0).toDict();
+    const dict = new GreaterThanFilter("f", 0).toDict();
 
     // Assert
-    expect(dict['op']).toBe('gt');
+    expect(dict["op"]).toBe("gt");
   });
 
-  it('should be equivalent to itself', () => {
+  it("should be equivalent to itself", () => {
     // Arrange
-    const f = new GreaterThanFilter('age', 18);
+    const f = new GreaterThanFilter("age", 18);
 
     // Act
     const result = f.isEquivalentTo(f);
@@ -31,10 +31,10 @@ describe('GreaterThanFilter', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should be equivalent to another GreaterThanFilter with same values', () => {
+  it("should be equivalent to another GreaterThanFilter with same values", () => {
     // Arrange
-    const f1 = new GreaterThanFilter('age', 18);
-    const f2 = new GreaterThanFilter('age', 18);
+    const f1 = new GreaterThanFilter("age", 18);
+    const f2 = new GreaterThanFilter("age", 18);
 
     // Act
     const result = f1.isEquivalentTo(f2);
@@ -43,10 +43,10 @@ describe('GreaterThanFilter', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should not be equivalent to a different GreaterThanFilter', () => {
+  it("should not be equivalent to a different GreaterThanFilter", () => {
     // Arrange
-    const f1 = new GreaterThanFilter('age', 18);
-    const f2 = new GreaterThanFilter('age', 21);
+    const f1 = new GreaterThanFilter("age", 18);
+    const f2 = new GreaterThanFilter("age", 21);
 
     // Act
     const result = f1.isEquivalentTo(f2);

--- a/test/greaterThanOrEqualFilter.test.ts
+++ b/test/greaterThanOrEqualFilter.test.ts
@@ -19,4 +19,39 @@ describe('GreaterThanOrEqualFilter', () => {
     // Assert
     expect(dict['op']).toBe('gte');
   });
+
+  it('should be equivalent to itself', () => {
+    // Arrange
+    const f = new GreaterThanOrEqualFilter('age', 18);
+
+    // Act
+    const result = f.isEquivalentTo(f);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it('should be equivalent to another GreaterThanOrEqualFilter with same values', () => {
+    // Arrange
+    const f1 = new GreaterThanOrEqualFilter('age', 18);
+    const f2 = new GreaterThanOrEqualFilter('age', 18);
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it('should not be equivalent to a different GreaterThanOrEqualFilter', () => {
+    // Arrange
+    const f1 = new GreaterThanOrEqualFilter('age', 18);
+    const f2 = new GreaterThanOrEqualFilter('age', 21);
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeFalsy();
+  });
 });

--- a/test/greaterThanOrEqualFilter.test.ts
+++ b/test/greaterThanOrEqualFilter.test.ts
@@ -1,28 +1,28 @@
-import { GreaterThanOrEqualFilter } from '../src/expressions';
+import { GreaterThanOrEqualFilter } from "../src/expressions";
 
-describe('GreaterThanOrEqualFilter', () => {
-  it('should serialize to correct dict', () => {
+describe("GreaterThanOrEqualFilter", () => {
+  it("should serialize to correct dict", () => {
     // Arrange
-    const f = new GreaterThanOrEqualFilter('age', 18);
+    const f = new GreaterThanOrEqualFilter("age", 18);
 
     // Act
     const result = f.toDict();
 
     // Assert
-    expect(result).toEqual({ field: 'age', op: 'gte', value: 18 });
+    expect(result).toEqual({ field: "age", op: "gte", value: 18 });
   });
 
-  it('op field should be gte', () => {
+  it("op field should be gte", () => {
     // Arrange / Act
-    const dict = new GreaterThanOrEqualFilter('f', 0).toDict();
+    const dict = new GreaterThanOrEqualFilter("f", 0).toDict();
 
     // Assert
-    expect(dict['op']).toBe('gte');
+    expect(dict["op"]).toBe("gte");
   });
 
-  it('should be equivalent to itself', () => {
+  it("should be equivalent to itself", () => {
     // Arrange
-    const f = new GreaterThanOrEqualFilter('age', 18);
+    const f = new GreaterThanOrEqualFilter("age", 18);
 
     // Act
     const result = f.isEquivalentTo(f);
@@ -31,10 +31,10 @@ describe('GreaterThanOrEqualFilter', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should be equivalent to another GreaterThanOrEqualFilter with same values', () => {
+  it("should be equivalent to another GreaterThanOrEqualFilter with same values", () => {
     // Arrange
-    const f1 = new GreaterThanOrEqualFilter('age', 18);
-    const f2 = new GreaterThanOrEqualFilter('age', 18);
+    const f1 = new GreaterThanOrEqualFilter("age", 18);
+    const f2 = new GreaterThanOrEqualFilter("age", 18);
 
     // Act
     const result = f1.isEquivalentTo(f2);
@@ -43,10 +43,10 @@ describe('GreaterThanOrEqualFilter', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should not be equivalent to a different GreaterThanOrEqualFilter', () => {
+  it("should not be equivalent to a different GreaterThanOrEqualFilter", () => {
     // Arrange
-    const f1 = new GreaterThanOrEqualFilter('age', 18);
-    const f2 = new GreaterThanOrEqualFilter('age', 21);
+    const f1 = new GreaterThanOrEqualFilter("age", 18);
+    const f2 = new GreaterThanOrEqualFilter("age", 21);
 
     // Act
     const result = f1.isEquivalentTo(f2);

--- a/test/lessThanFilter.test.ts
+++ b/test/lessThanFilter.test.ts
@@ -19,4 +19,39 @@ describe('LessThanFilter', () => {
     // Assert
     expect(dict['op']).toBe('lt');
   });
+
+  it('should be equivalent to itself', () => {
+    // Arrange
+    const f = new LessThanFilter('age', 65);
+
+    // Act
+    const result = f.isEquivalentTo(f);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it('should be equivalent to another LessThanFilter with same values', () => {
+    // Arrange
+    const f1 = new LessThanFilter('age', 65);
+    const f2 = new LessThanFilter('age', 65);
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it('should not be equivalent to a different LessThanFilter', () => {
+    // Arrange
+    const f1 = new LessThanFilter('age', 65);
+    const f2 = new LessThanFilter('age', 50);
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeFalsy();
+  });
 });

--- a/test/lessThanFilter.test.ts
+++ b/test/lessThanFilter.test.ts
@@ -1,28 +1,28 @@
-import { LessThanFilter } from '../src/expressions';
+import { LessThanFilter } from "../src/expressions";
 
-describe('LessThanFilter', () => {
-  it('should serialize to correct dict', () => {
+describe("LessThanFilter", () => {
+  it("should serialize to correct dict", () => {
     // Arrange
-    const f = new LessThanFilter('age', 65);
+    const f = new LessThanFilter("age", 65);
 
     // Act
     const result = f.toDict();
 
     // Assert
-    expect(result).toEqual({ field: 'age', op: 'lt', value: 65 });
+    expect(result).toEqual({ field: "age", op: "lt", value: 65 });
   });
 
-  it('op field should be lt', () => {
+  it("op field should be lt", () => {
     // Arrange / Act
-    const dict = new LessThanFilter('f', 0).toDict();
+    const dict = new LessThanFilter("f", 0).toDict();
 
     // Assert
-    expect(dict['op']).toBe('lt');
+    expect(dict["op"]).toBe("lt");
   });
 
-  it('should be equivalent to itself', () => {
+  it("should be equivalent to itself", () => {
     // Arrange
-    const f = new LessThanFilter('age', 65);
+    const f = new LessThanFilter("age", 65);
 
     // Act
     const result = f.isEquivalentTo(f);
@@ -31,10 +31,10 @@ describe('LessThanFilter', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should be equivalent to another LessThanFilter with same values', () => {
+  it("should be equivalent to another LessThanFilter with same values", () => {
     // Arrange
-    const f1 = new LessThanFilter('age', 65);
-    const f2 = new LessThanFilter('age', 65);
+    const f1 = new LessThanFilter("age", 65);
+    const f2 = new LessThanFilter("age", 65);
 
     // Act
     const result = f1.isEquivalentTo(f2);
@@ -43,10 +43,10 @@ describe('LessThanFilter', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should not be equivalent to a different LessThanFilter', () => {
+  it("should not be equivalent to a different LessThanFilter", () => {
     // Arrange
-    const f1 = new LessThanFilter('age', 65);
-    const f2 = new LessThanFilter('age', 50);
+    const f1 = new LessThanFilter("age", 65);
+    const f2 = new LessThanFilter("age", 50);
 
     // Act
     const result = f1.isEquivalentTo(f2);

--- a/test/lessThanOrEqualFilter.test.ts
+++ b/test/lessThanOrEqualFilter.test.ts
@@ -1,28 +1,28 @@
-import { LessThanOrEqualFilter } from '../src/expressions';
+import { LessThanOrEqualFilter } from "../src/expressions";
 
-describe('LessThanOrEqualFilter', () => {
-  it('should serialize to correct dict', () => {
+describe("LessThanOrEqualFilter", () => {
+  it("should serialize to correct dict", () => {
     // Arrange
-    const f = new LessThanOrEqualFilter('age', 65);
+    const f = new LessThanOrEqualFilter("age", 65);
 
     // Act
     const result = f.toDict();
 
     // Assert
-    expect(result).toEqual({ field: 'age', op: 'lte', value: 65 });
+    expect(result).toEqual({ field: "age", op: "lte", value: 65 });
   });
 
-  it('op field should be lte', () => {
+  it("op field should be lte", () => {
     // Arrange / Act
-    const dict = new LessThanOrEqualFilter('f', 0).toDict();
+    const dict = new LessThanOrEqualFilter("f", 0).toDict();
 
     // Assert
-    expect(dict['op']).toBe('lte');
+    expect(dict["op"]).toBe("lte");
   });
 
-  it('should be equivalent to itself', () => {
+  it("should be equivalent to itself", () => {
     // Arrange
-    const f = new LessThanOrEqualFilter('age', 65);
+    const f = new LessThanOrEqualFilter("age", 65);
 
     // Act
     const result = f.isEquivalentTo(f);
@@ -31,10 +31,10 @@ describe('LessThanOrEqualFilter', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should be equivalent to another LessThanOrEqualFilter with same values', () => {
+  it("should be equivalent to another LessThanOrEqualFilter with same values", () => {
     // Arrange
-    const f1 = new LessThanOrEqualFilter('age', 65);
-    const f2 = new LessThanOrEqualFilter('age', 65);
+    const f1 = new LessThanOrEqualFilter("age", 65);
+    const f2 = new LessThanOrEqualFilter("age", 65);
 
     // Act
     const result = f1.isEquivalentTo(f2);
@@ -43,10 +43,10 @@ describe('LessThanOrEqualFilter', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should not be equivalent to a different LessThanOrEqualFilter', () => {
+  it("should not be equivalent to a different LessThanOrEqualFilter", () => {
     // Arrange
-    const f1 = new LessThanOrEqualFilter('age', 65);
-    const f2 = new LessThanOrEqualFilter('age', 50);
+    const f1 = new LessThanOrEqualFilter("age", 65);
+    const f2 = new LessThanOrEqualFilter("age", 50);
 
     // Act
     const result = f1.isEquivalentTo(f2);

--- a/test/lessThanOrEqualFilter.test.ts
+++ b/test/lessThanOrEqualFilter.test.ts
@@ -19,4 +19,39 @@ describe('LessThanOrEqualFilter', () => {
     // Assert
     expect(dict['op']).toBe('lte');
   });
+
+  it('should be equivalent to itself', () => {
+    // Arrange
+    const f = new LessThanOrEqualFilter('age', 65);
+
+    // Act
+    const result = f.isEquivalentTo(f);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it('should be equivalent to another LessThanOrEqualFilter with same values', () => {
+    // Arrange
+    const f1 = new LessThanOrEqualFilter('age', 65);
+    const f2 = new LessThanOrEqualFilter('age', 65);
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it('should not be equivalent to a different LessThanOrEqualFilter', () => {
+    // Arrange
+    const f1 = new LessThanOrEqualFilter('age', 65);
+    const f2 = new LessThanOrEqualFilter('age', 50);
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeFalsy();
+  });
 });

--- a/test/notFilter.test.ts
+++ b/test/notFilter.test.ts
@@ -1,21 +1,21 @@
-import { EqualsFilter, NotFilter } from '../src/expressions';
+import { EqualsFilter, NotFilter } from "../src/expressions";
 
-describe('NotFilter', () => {
-  it('should serialize with logic not', () => {
+describe("NotFilter", () => {
+  it("should serialize with logic not", () => {
     // Arrange
-    const f = new NotFilter(new EqualsFilter('deleted', true));
+    const f = new NotFilter(new EqualsFilter("deleted", true));
 
     // Act
     const result = f.toDict();
 
     // Assert
-    expect(result['logic']).toBe('not');
-    expect((result['filters'] as unknown[]).length).toBe(1);
+    expect(result["logic"]).toBe("not");
+    expect((result["filters"] as unknown[]).length).toBe(1);
   });
 
-  it('should wrap the inner filter', () => {
+  it("should wrap the inner filter", () => {
     // Arrange
-    const inner = new EqualsFilter('active', false);
+    const inner = new EqualsFilter("active", false);
 
     // Act
     const f = new NotFilter(inner);
@@ -24,9 +24,9 @@ describe('NotFilter', () => {
     expect(f.filter).toBe(inner);
   });
 
-  it('should be equivalent to itself', () => {
+  it("should be equivalent to itself", () => {
     // Arrange
-    const f = new NotFilter(new EqualsFilter('deleted', true));
+    const f = new NotFilter(new EqualsFilter("deleted", true));
 
     // Act
     const result = f.isEquivalentTo(f);
@@ -35,10 +35,10 @@ describe('NotFilter', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should be equivalent to another NotFilter with same filter', () => {
+  it("should be equivalent to another NotFilter with same filter", () => {
     // Arrange
-    const f1 = new NotFilter(new EqualsFilter('deleted', true));
-    const f2 = new NotFilter(new EqualsFilter('deleted', true));
+    const f1 = new NotFilter(new EqualsFilter("deleted", true));
+    const f2 = new NotFilter(new EqualsFilter("deleted", true));
 
     // Act
     const result = f1.isEquivalentTo(f2);
@@ -47,10 +47,10 @@ describe('NotFilter', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should not be equivalent to a different NotFilter', () => {
+  it("should not be equivalent to a different NotFilter", () => {
     // Arrange
-    const f1 = new NotFilter(new EqualsFilter('deleted', true));
-    const f2 = new NotFilter(new EqualsFilter('deleted', false));
+    const f1 = new NotFilter(new EqualsFilter("deleted", true));
+    const f2 = new NotFilter(new EqualsFilter("deleted", false));
 
     // Act
     const result = f1.isEquivalentTo(f2);

--- a/test/notFilter.test.ts
+++ b/test/notFilter.test.ts
@@ -23,4 +23,39 @@ describe('NotFilter', () => {
     // Assert
     expect(f.filter).toBe(inner);
   });
+
+  it('should be equivalent to itself', () => {
+    // Arrange
+    const f = new NotFilter(new EqualsFilter('deleted', true));
+
+    // Act
+    const result = f.isEquivalentTo(f);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it('should be equivalent to another NotFilter with same filter', () => {
+    // Arrange
+    const f1 = new NotFilter(new EqualsFilter('deleted', true));
+    const f2 = new NotFilter(new EqualsFilter('deleted', true));
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it('should not be equivalent to a different NotFilter', () => {
+    // Arrange
+    const f1 = new NotFilter(new EqualsFilter('deleted', true));
+    const f2 = new NotFilter(new EqualsFilter('deleted', false));
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeFalsy();
+  });
 });

--- a/test/oneOfFilter.test.ts
+++ b/test/oneOfFilter.test.ts
@@ -1,12 +1,12 @@
-import { EqualsFilter, OrFilter } from "../src/expressions";
+import { EqualsFilter, OneOfFilter } from "../src/expressions";
 
-describe("OrFilter", () => {
+describe("OneOfFilter", () => {
   it("should serialize with logic and nested filters", () => {
     // Arrange
-    const f = new OrFilter(
+    const f = new OneOfFilter([
       new EqualsFilter("status", "active"),
       new EqualsFilter("status", "pending"),
-    );
+    ]);
 
     // Act
     const result = f.toDict();
@@ -18,10 +18,10 @@ describe("OrFilter", () => {
 
   it("should be equivalent to itself", () => {
     // Arrange
-    const f = new OrFilter(
+    const f = new OneOfFilter([
       new EqualsFilter("status", "active"),
       new EqualsFilter("status", "pending"),
-    );
+    ]);
 
     // Act
     const result = f.isEquivalentTo(f);
@@ -30,16 +30,16 @@ describe("OrFilter", () => {
     expect(result).toBeTruthy();
   });
 
-  it("should be equivalent to another OrFilter with same filters", () => {
+  it("should be equivalent to another OneOfFilter with same filters", () => {
     // Arrange
-    const f1 = new OrFilter(
+    const f1 = new OneOfFilter([
       new EqualsFilter("status", "active"),
       new EqualsFilter("status", "pending"),
-    );
-    const f2 = new OrFilter(
+    ]);
+    const f2 = new OneOfFilter([
       new EqualsFilter("status", "active"),
       new EqualsFilter("status", "pending"),
-    );
+    ]);
 
     // Act
     const result = f1.isEquivalentTo(f2);
@@ -48,16 +48,16 @@ describe("OrFilter", () => {
     expect(result).toBeTruthy();
   });
 
-  it("should not be equivalent to a different OrFilter", () => {
+  it("should not be equivalent to a different OneOfFilter", () => {
     // Arrange
-    const f1 = new OrFilter(
+    const f1 = new OneOfFilter([
       new EqualsFilter("status", "active"),
       new EqualsFilter("status", "pending"),
-    );
-    const f2 = new OrFilter(
+    ]);
+    const f2 = new OneOfFilter([
       new EqualsFilter("status", "active"),
       new EqualsFilter("status", "disabled"),
-    );
+    ]);
 
     // Act
     const result = f1.isEquivalentTo(f2);

--- a/test/startsWithFilter.test.ts
+++ b/test/startsWithFilter.test.ts
@@ -1,28 +1,28 @@
-import { StartsWithFilter } from '../src/expressions';
+import { StartsWithFilter } from "../src/expressions";
 
-describe('StartsWithFilter', () => {
-  it('should serialize to correct dict', () => {
+describe("StartsWithFilter", () => {
+  it("should serialize to correct dict", () => {
     // Arrange
-    const f = new StartsWithFilter('name', 'Bat');
+    const f = new StartsWithFilter("name", "Bat");
 
     // Act
     const result = f.toDict();
 
     // Assert
-    expect(result).toEqual({ field: 'name', op: 'startswith', value: 'Bat' });
+    expect(result).toEqual({ field: "name", op: "startswith", value: "Bat" });
   });
 
-  it('op field should be startswith', () => {
+  it("op field should be startswith", () => {
     // Arrange / Act
-    const dict = new StartsWithFilter('f', 'v').toDict();
+    const dict = new StartsWithFilter("f", "v").toDict();
 
     // Assert
-    expect(dict['op']).toBe('startswith');
+    expect(dict["op"]).toBe("startswith");
   });
 
-  it('should be equivalent to itself', () => {
+  it("should be equivalent to itself", () => {
     // Arrange
-    const f = new StartsWithFilter('name', 'Bat');
+    const f = new StartsWithFilter("name", "Bat");
 
     // Act
     const result = f.isEquivalentTo(f);
@@ -31,10 +31,10 @@ describe('StartsWithFilter', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should be equivalent to another StartsWithFilter with same values', () => {
+  it("should be equivalent to another StartsWithFilter with same values", () => {
     // Arrange
-    const f1 = new StartsWithFilter('name', 'Bat');
-    const f2 = new StartsWithFilter('name', 'Bat');
+    const f1 = new StartsWithFilter("name", "Bat");
+    const f2 = new StartsWithFilter("name", "Bat");
 
     // Act
     const result = f1.isEquivalentTo(f2);
@@ -43,10 +43,10 @@ describe('StartsWithFilter', () => {
     expect(result).toBeTruthy();
   });
 
-  it('should not be equivalent to a different StartsWithFilter', () => {
+  it("should not be equivalent to a different StartsWithFilter", () => {
     // Arrange
-    const f1 = new StartsWithFilter('name', 'Bat');
-    const f2 = new StartsWithFilter('name', 'Super');
+    const f1 = new StartsWithFilter("name", "Bat");
+    const f2 = new StartsWithFilter("name", "Super");
 
     // Act
     const result = f1.isEquivalentTo(f2);

--- a/test/startsWithFilter.test.ts
+++ b/test/startsWithFilter.test.ts
@@ -19,4 +19,39 @@ describe('StartsWithFilter', () => {
     // Assert
     expect(dict['op']).toBe('startswith');
   });
+
+  it('should be equivalent to itself', () => {
+    // Arrange
+    const f = new StartsWithFilter('name', 'Bat');
+
+    // Act
+    const result = f.isEquivalentTo(f);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it('should be equivalent to another StartsWithFilter with same values', () => {
+    // Arrange
+    const f1 = new StartsWithFilter('name', 'Bat');
+    const f2 = new StartsWithFilter('name', 'Bat');
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
+
+  it('should not be equivalent to a different StartsWithFilter', () => {
+    // Arrange
+    const f1 = new StartsWithFilter('name', 'Bat');
+    const f2 = new StartsWithFilter('name', 'Super');
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeFalsy();
+  });
 });


### PR DESCRIPTION
Introduce an `isEquivalentTo` method across all filter classes to standardize equivalence checks.
Update documentation to reflect decisions on handling equivalence and synchronization in multi-agent delivery. enhance test coverage for equivalence scenarios, including a dedicated test suite for `OneOfFilter`.