### PR TITLE
✨feat: enhance OrFilter equivalence checks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "ghcr.io/devcontainers/features/copilot-cli": {},
     "ghcr.io/jpawlowski/devcontainer-features/cascadia-code:1": {},
     "ghcr.io/nils-geistmann/devcontainers-features/zsh": {
-      "plugins": "git npm gh git-prompt branch"
+      "plugins": "git npm gh git-prompt"
     },
     "ghcr.io/devcontainers-extra/features/jest": {}
   },

--- a/src/equivalence.ts
+++ b/src/equivalence.ts
@@ -1,6 +1,7 @@
 import { IFilter } from "./iFilter";
 
 type AndLikeFilter = IFilter & { filters: IFilter[] };
+type OrLikeFilter = IFilter & { left: IFilter; right: IFilter };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -56,6 +57,20 @@ const getAndFilters = (filter: IFilter): IFilter[] | undefined => {
   return andFilter.filters;
 };
 
+const getOrFilters = (filter: IFilter): IFilter[] | undefined => {
+  const dict = filter.toDict();
+  if (dict["logic"] !== "or") {
+    return undefined;
+  }
+
+  const orFilter = filter as Partial<OrLikeFilter>;
+  if (!isFilter(orFilter.left) || !isFilter(orFilter.right)) {
+    return undefined;
+  }
+
+  return [orFilter.left, orFilter.right];
+};
+
 export const areFiltersEquivalent = (
   left: IFilter,
   right: IFilter,
@@ -75,6 +90,16 @@ export const areFiltersEquivalent = (
 
   const rightAndFilters = getAndFilters(right);
   if (rightAndFilters?.every((child) => child.isEquivalentTo(left))) {
+    return true;
+  }
+
+  const leftOrFilters = getOrFilters(left);
+  if (leftOrFilters?.every((child) => child.isEquivalentTo(right))) {
+    return true;
+  }
+
+  const rightOrFilters = getOrFilters(right);
+  if (rightOrFilters?.every((child) => child.isEquivalentTo(left))) {
     return true;
   }
 

--- a/src/orFilter.ts
+++ b/src/orFilter.ts
@@ -12,6 +12,27 @@ export class OrFilter implements IFilter {
   }
 
   public isEquivalentTo(other: IFilter): boolean {
+    // OR is commutative: (A OR B) is equivalent to (B OR A).
+    const otherDict = other.toDict();
+    const otherOr = other as Partial<OrFilter>;
+    if (
+      otherDict["logic"] === "or" &&
+      otherOr.left !== undefined &&
+      otherOr.right !== undefined
+    ) {
+      const sameOrder =
+        areFiltersEquivalent(this.left, otherOr.left) &&
+        areFiltersEquivalent(this.right, otherOr.right);
+      if (sameOrder) {
+        return true;
+      }
+
+      return (
+        areFiltersEquivalent(this.left, otherOr.right) &&
+        areFiltersEquivalent(this.right, otherOr.left)
+      );
+    }
+
     return areFiltersEquivalent(this, other);
   }
 }

--- a/test/equalsFilter.test.ts
+++ b/test/equalsFilter.test.ts
@@ -1,4 +1,4 @@
-import { AndFilter, EqualsFilter } from "../src/expressions";
+import { AndFilter, EqualsFilter, OrFilter } from "../src/expressions";
 
 const isEquivalentTo = (left: unknown, right: unknown): boolean => {
   return (
@@ -99,6 +99,21 @@ describe("EqualsFilter", () => {
 
       // Assert
       expect(result).toBeFalsy();
+    });
+
+    it("should be equivalent to an OrFilter if it only contains filters equivalent to this EqualsFilter", () => {
+      // Arrange
+      const f1 = new EqualsFilter("status", "active");
+      const f2 = new OrFilter(
+        new EqualsFilter("status", "active"),
+        new EqualsFilter("status", "active"),
+      );
+
+      // Act
+      const result = f1.isEquivalentTo(f2);
+
+      // Assert
+      expect(result).toBeTruthy();
     });
   });
 });

--- a/test/orFilter.test.ts
+++ b/test/orFilter.test.ts
@@ -83,4 +83,19 @@ describe("OrFilter", () => {
     // Assert
     expect(result).toBeTruthy();
   });
+
+  it("should be equivalent to an EqualsFilter if it only contains filters equivalent to that EqualsFilter", () => {
+    // Arrange
+    const f1 = new OrFilter(
+      new EqualsFilter("status", "active"),
+      new EqualsFilter("status", "active"),
+    );
+    const f2 = new EqualsFilter("status", "active");
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
 });

--- a/test/orFilter.test.ts
+++ b/test/orFilter.test.ts
@@ -65,4 +65,22 @@ describe("OrFilter", () => {
     // Assert
     expect(result).toBeFalsy();
   });
+
+  it("should be equivalent to another OrFilter with same filters in different order", () => {
+    // Arrange
+    const f1 = new OrFilter(
+      new EqualsFilter("status", "active"),
+      new EqualsFilter("status", "pending"),
+    );
+    const f2 = new OrFilter(
+      new EqualsFilter("status", "pending"),
+      new EqualsFilter("status", "active"),
+    );
+
+    // Act
+    const result = f1.isEquivalentTo(f2);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Improve the `isEquivalentTo` method to support equivalence checks for `OrFilter`, allowing for filters to be considered equivalent regardless of their order. 

Additionally, remove the unnecessary 'branch' plugin from the zsh configuration.