### PR TITLE
✨ feat: `NotFilter` equivalence check and refactor code structure

### DIFF
--- a/src/equivalence.ts
+++ b/src/equivalence.ts
@@ -116,17 +116,17 @@ export const areFiltersEquivalent = (
 };
 
 const getNotFilter = (filter: IFilter): IFilter | undefined => {
+  let result: IFilter | undefined = undefined;
+
   const dict = filter.toDict();
-  if (dict["logic"] !== "not") {
-    return undefined;
+  if (dict["logic"] === "not") {
+    const notFilter = filter as Partial<NotLikeFilter>;
+    if (isFilter(notFilter.filter)) {
+      result = notFilter.filter;
+    }
   }
 
-  const notFilter = filter as Partial<NotLikeFilter>;
-  if (!isFilter(notFilter.filter)) {
-    return undefined;
-  }
-
-  return notFilter.filter;
+  return result;
 };
 
 /**
@@ -138,24 +138,16 @@ const getNotFilter = (filter: IFilter): IFilter | undefined => {
  * - x returns x
  */
 const unwrapDoubleNotFilters = (filter: IFilter): IFilter => {
-  let current = filter;
-  let notCount = 0;
+  const inner = getNotFilter(filter);
+  let result = filter;
 
-  // Count consecutive NOT filters
-  while (true) {
-    const inner = getNotFilter(current);
-    if (inner === undefined) {
-      break;
+  if (inner !== undefined) {
+    const innerUnwrapped = getNotFilter(inner);
+    if (innerUnwrapped !== undefined) {
+      // We have at least 2 consecutive NOTs, recurse on the unwrapped inner filter
+      result = unwrapDoubleNotFilters(innerUnwrapped);
     }
-    current = inner;
-    notCount++;
   }
 
-  // If even number of NOTs, return the unwrapped filter
-  if (notCount % 2 === 0) {
-    return current;
-  }
-
-  // If odd number of NOTs, return the original filter
-  return filter;
+  return result;
 };

--- a/src/equivalence.ts
+++ b/src/equivalence.ts
@@ -2,6 +2,7 @@ import { IFilter } from "./iFilter";
 
 type AndLikeFilter = IFilter & { filters: IFilter[] };
 type OrLikeFilter = IFilter & { left: IFilter; right: IFilter };
+type NotLikeFilter = IFilter & { filter: IFilter };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -103,5 +104,58 @@ export const areFiltersEquivalent = (
     return true;
   }
 
+  // Handle pairs of NOT filters: NOT(NOT(x)) = x
+  const leftUnwrapped = unwrapDoubleNotFilters(left);
+  const rightUnwrapped = unwrapDoubleNotFilters(right);
+
+  if (leftUnwrapped !== left || rightUnwrapped !== right) {
+    return areFiltersEquivalent(leftUnwrapped, rightUnwrapped);
+  }
+
   return false;
+};
+
+const getNotFilter = (filter: IFilter): IFilter | undefined => {
+  const dict = filter.toDict();
+  if (dict["logic"] !== "not") {
+    return undefined;
+  }
+
+  const notFilter = filter as Partial<NotLikeFilter>;
+  if (!isFilter(notFilter.filter)) {
+    return undefined;
+  }
+
+  return notFilter.filter;
+};
+
+/**
+ * Unwraps pairs of NotFilter.
+ * Since NOT(NOT(x)) = x, this function removes pairs of NOT operations.
+ * For example:
+ * - NOT(NOT(x)) returns x
+ * - NOT(NOT(NOT(x))) returns NOT(x)
+ * - x returns x
+ */
+const unwrapDoubleNotFilters = (filter: IFilter): IFilter => {
+  let current = filter;
+  let notCount = 0;
+
+  // Count consecutive NOT filters
+  while (true) {
+    const inner = getNotFilter(current);
+    if (inner === undefined) {
+      break;
+    }
+    current = inner;
+    notCount++;
+  }
+
+  // If even number of NOTs, return the unwrapped filter
+  if (notCount % 2 === 0) {
+    return current;
+  }
+
+  // If odd number of NOTs, return the original filter
+  return filter;
 };

--- a/test/notFilter.test.ts
+++ b/test/notFilter.test.ts
@@ -58,4 +58,16 @@ describe("NotFilter", () => {
     // Assert
     expect(result).toBeFalsy();
   });
+
+  it("should be equivalent to inner filter when wrapped with a pair of NotFilter", () => {
+    // Arrange
+    const inner = new EqualsFilter("active", false);
+    const f = new NotFilter(new NotFilter(inner));
+
+    // Act
+    const result = f.isEquivalentTo(inner);
+
+    // Assert
+    expect(result).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Enhance the equivalence check for NotFilters by handling pairs of NotFilters, ensuring logical consistency. Refactor functions to maintain a single exit point and eliminate infinite loops, improving code quality. Add tests to verify the new behavior.